### PR TITLE
fixes, enhancements and code cleanup for custom easyblock for Clang-AOMP

### DIFF
--- a/easybuild/easyblocks/c/clang_aomp.py
+++ b/easybuild/easyblocks/c/clang_aomp.py
@@ -33,12 +33,11 @@ import os
 
 from easybuild.easyblocks.clang import DEFAULT_TARGETS_MAP as LLVM_ARCH_MAP
 from easybuild.easyblocks.generic.bundle import Bundle
+from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError, print_msg, print_warning
-from easybuild.tools.config import build_option
 from easybuild.tools.modules import get_software_root
-from easybuild.tools.systemtools import AARCH64, POWER, X86_64
-from easybuild.tools.systemtools import get_cpu_architecture, get_shared_lib_ext
+from easybuild.tools.systemtools import AARCH64, POWER, X86_64, get_cpu_architecture, get_shared_lib_ext
 
 
 # Default AMD GPU architectures to build for
@@ -50,29 +49,34 @@ from easybuild.tools.systemtools import get_cpu_architecture, get_shared_lib_ext
 DEFAULT_GFX_ARCHS = ['gfx900', 'gfx902', 'gfx906', 'gfx908', 'gfx90a', 'gfx1030', 'gfx1031']
 
 
-class EB_Clang_AOMP(Bundle):
+class EB_Clang_minus_AOMP(Bundle):
     """
     Self-contained build of AOMP version of Clang
     """
 
     @staticmethod
     def extra_options():
+        gfx_list_help_msg = "AMD GPU architectures to build for (if None, use defaults: %s)"
         extra_vars = {
-            'gfx_list': [[], "AMD GPU architectures to build for", CUSTOM],
+            'gfx_list': [None, gfx_list_help_msg % ', '.join(DEFAULT_GFX_ARCHS), CUSTOM],
         }
         return Bundle.extra_options(extra_vars)
 
     def __init__(self, *args, **kwargs):
-        super(EB_Clang_AOMP, self).__init__(*args, **kwargs)
+        """Easyblock constructor."""
+        super(EB_Clang_minus_AOMP, self).__init__(*args, **kwargs)
+
         # List of LLVM target architectures to build for, extended in the 'prepare_step'
         self.target_archs = ['AMDGPU']
+
         # Mapping from known ROCm components to their configure method
         self.cfg_method = {
-            'llvm-project': self._configure_llvm,
-            'ROCm-Device-Libs': self._configure_device_libs,
-            'Clang-OpenMP': self._configure_omp,
             'aomp-extras': self._configure_aomp_extras,
+            'Clang-OpenMP': self._configure_omp,
+            'llvm-project': self._configure_llvm,
+            'ROCm-Device-Libs': self._configure_rocm_device_libs,
         }
+
         # Prepare configuration options that point to the expected Clang build
         self.llvm_compiler_flags = [
             "-DCMAKE_C_COMPILER=%s" % os.path.join(self.installdir, 'bin', 'clang'),
@@ -80,10 +84,16 @@ class EB_Clang_AOMP(Bundle):
             "-DLLVM_INSTALL_PREFIX=%s" % self.installdir,
             "-DLLVM_DIR=%s" % self.installdir,
         ]
+
         # Variables to be filled in the prepare step
-        self.amd_gfx_archs = []
         self.cuda_archs = []
         self.device_lib_path = None
+
+        # Setup AMD GFX list to build for
+        if self.cfg['gfx_list']:
+            self.amd_gfx_archs = self.cfg['gfx_list']
+        else:
+            self.amd_gfx_archs = DEFAULT_GFX_ARCHS
 
     def prepare_sources(self):
         """
@@ -91,44 +101,47 @@ class EB_Clang_AOMP(Bundle):
         """
         # Detect CPU architecture and setup build targets for LLVM
         cpu_arch = get_cpu_architecture()
-        if cpu_arch not in LLVM_ARCH_MAP:
-            raise EasyBuildError('Unknown CPU architecture for LLVM: %s' % cpu_arch)
-        self.target_archs.append(LLVM_ARCH_MAP[cpu_arch][0])
-        # If CUDA is loaded when building, try to build CUDA offload backend
+        if cpu_arch in LLVM_ARCH_MAP:
+            self.target_archs.append(LLVM_ARCH_MAP[cpu_arch][0])
+        else:
+            raise EasyBuildError('Unknown CPU architecture for LLVM: %s', cpu_arch)
+
+        # If CUDA is loaded when building, build CUDA offload backend
         if get_software_root('CUDA'):
             self.target_archs.append('NVPTX')
-            ec_cuda_cc = self.cfg['cuda_compute_capabilities']
-            cfg_cuda_cc = build_option('cuda_compute_capabilities')
-            cuda_cc = cfg_cuda_cc or ec_cuda_cc or []
+
+            # a specific set of CUDA compute capabilities must be specified,
+            # via --cuda-compute-capabilities EasyBuild configuration option or
+            # via cuda_compute_capabilities easyconfig parameter
+            cuda_cc = self.cfg.get_cuda_cc_template_value('cuda_compute_capabilities').split(',')
             if not cuda_cc:
                 raise EasyBuildError("Can't build Clang-AOMP with CUDA support "
                                      "without specifying 'cuda-compute-capabilities'")
             self.cuda_archs = [cc.replace('.', '') for cc in cuda_cc]
             self.log.info("Building offload support for the following CUDA architectures: '%s'",
-                          ' '.join(self.amd_gfx_archs))
+                          ' '.join(self.cuda_archs))
+
         self.log.info("Building LLVM for the following architectures: '%s'", ';'.join(self.target_archs))
-        # Setup AMD GFX list to build for
-        if self.cfg['gfx_list']:
-            self.amd_gfx_archs = self.cfg['gfx_list']
-        else:
-            self.amd_gfx_archs = DEFAULT_GFX_ARCHS
+
         self.log.info("Building offload support for the following AMD architectures: '%s'",
                       ' '.join(self.amd_gfx_archs))
+
         # Ensure necessary libraries are downloaded and can be found
         device_lib_dir_pattern = os.path.join(self.builddir, 'ROCm-Device-Libs-*')
         hits = glob.glob(device_lib_dir_pattern)
         if len(hits) == 1:
             self.device_lib_path = hits[0]
         else:
-            raise EasyBuildError("Could not find 'ROCm-Device-Libs' source directory")
+            raise EasyBuildError("Could not find 'ROCm-Device-Libs' source directory in %s", self.builddir)
 
     def configure_step(self):
         """
         Go through each component and setup configuration for the later Bundle install step
         """
-        super(EB_Clang_AOMP, self).configure_step()
+        super(EB_Clang_minus_AOMP, self).configure_step()
 
         self.prepare_sources()
+
         num_comps = len(self.cfg['components'])
         for idx, comp in enumerate(self.comp_cfgs):
             name = comp['name']
@@ -152,15 +165,18 @@ class EB_Clang_AOMP(Bundle):
                      'lib/libdevice'],
         }
         custom_commands = ['clang --help', 'clang++ --help']
+
+        libs = ['aompextras', 'omptarget']
+        libdevice = os.path.join('lib', 'libdevice')
+
         # Check that all AMD GFX libraries were built
         for gfx in self.amd_gfx_archs:
-            custom_paths['files'].append('lib/libdevice/libomptarget-amdgcn-%s.bc' % gfx)
-            custom_paths['files'].append('lib/libdevice/libaompextras-amdgcn-%s.bc' % gfx)
-            custom_paths['files'].append('lib/libdevice/libm-amdgcn-%s.bc' % gfx)
+            custom_paths['files'].extend([os.path.join(libdevice, 'lib%s-amdgcn-%s.bc' % (x, gfx)) for x in libs])
+
         # Check that CPU target OpenMP offloading library was built
         arch = get_cpu_architecture()
-        # Check architecture explicitly since Clang uses potentially
-        # different names
+
+        # Check architecture explicitly since Clang uses potentially different names
         if arch == X86_64:
             arch = 'x86_64'
         elif arch == POWER:
@@ -169,16 +185,20 @@ class EB_Clang_AOMP(Bundle):
             arch = 'aarch64'
         else:
             print_warning("Unknown CPU architecture (%s) for OpenMP offloading!" % arch)
-        custom_paths['files'].append('lib/libomptarget.rtl.%s.%s' % (arch, shlib_ext))
+
+        custom_paths['files'].append(os.path.join('lib', 'libomptarget.rtl.%s.%s' % (arch, shlib_ext)))
+
         # If CUDA offloading support was requested, check that correct omptarget was built
         if get_software_root('CUDA'):
-            custom_paths['files'].append('lib/libomptarget.rtl.cuda.%s' % shlib_ext)
+            custom_paths['files'].append(os.path.join('lib', 'libomptarget.rtl.cuda.%s' % shlib_ext))
+
             for arch in self.cuda_archs:
                 sm_arch = 'sm_%s' % arch
-                custom_paths['files'].append('lib/libdevice/libomptarget-nvptx-%s' % sm_arch)
-                custom_paths['files'].append('lib/libdevice/libaompextras-nvptx-%s' % sm_arch)
-                custom_paths['files'].append('lib/libdevice/libm-nvptx-%s' % sm_arch)
-        super(EB_Clang_AOMP, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+                custom_paths['files'].extend([os.path.join(libdevice, 'lib%s-nvptx-%s' % (x, sm_arch)) for x in libs])
+
+        # need to bypass sanity_check_step of Bundle, because it only loads the generated module
+        # unless custom paths or commands are specified in the easyconfig
+        EasyBlock.sanity_check_step(self, custom_paths=custom_paths, custom_commands=custom_commands)
 
     def _configure_llvm(self, component):
         """
@@ -186,24 +206,27 @@ class EB_Clang_AOMP(Bundle):
         """
         comp_dir = '%s-%s' % (component['name'], component['version'])
         component['srcdir'] = os.path.join(comp_dir, 'llvm')
+
         # Need to unset $CPATH to avoid that libunwind is pulled in via Mesa
         # dependency and interrupts building of LLVM
         component['prebuildopts'] = "unset CPATH && "
-        # Setup configuration options for LLVM
-        component['configopts'] = "-DLLVM_ENABLE_PROJECTS='clang;lld;compiler-rt' "
-        component['configopts'] += "-DCLANG_DEFAULT_LINKER=lld "
-        component['configopts'] += "-DGCC_INSTALL_PREFIX=$EBROOTGCC "
-        component['configopts'] += "-DLLVM_ENABLE_ASSERTIONS=ON "
-        component['configopts'] += "-DLLVM_ENABLE_BINDINGS=OFF "
-        component['configopts'] += "-DLLVM_INCLUDE_BENCHMARKS=OFF "
-        component['configopts'] += "-DLLVM_TARGETS_TO_BUILD='%s'" % ';'.join(self.target_archs)
 
-    def _configure_device_libs(self, component):
+        # Setup configuration options for LLVM
+        component['configopts'] = ' '.join([
+            "-DLLVM_ENABLE_PROJECTS='clang;lld;compiler-rt'",
+            "-DCLANG_DEFAULT_LINKER=lld",
+            "-DGCC_INSTALL_PREFIX=$EBROOTGCC",
+            "-DLLVM_ENABLE_ASSERTIONS=ON",
+            "-DLLVM_ENABLE_BINDINGS=OFF",
+            "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+            "-DLLVM_TARGETS_TO_BUILD='%s'" % ';'.join(self.target_archs),
+        ])
+
+    def _configure_rocm_device_libs(self, component):
         """
-        Setup device libs such that it is built with the local LLVM build
+        Setup ROCm device libs such that it is built with the local LLVM build
         """
-        component['configopts'] = ' '.join(self.llvm_compiler_flags)
-        component['configopts'] += " -DBUILD_HC_LIB=OFF"
+        component['configopts'] = ' '.join(self.llvm_compiler_flags + ['-DBUILD_HC_LIB=OFF'])
 
     def _configure_omp(self, component):
         """
@@ -212,25 +235,32 @@ class EB_Clang_AOMP(Bundle):
         llvm_include_dir = os.path.join(self.installdir, 'include', 'llvm')
         comp_dir = 'llvm-project-%s' % component['version']
         component['srcdir'] = os.path.join(comp_dir, 'openmp')
+
         component['preconfigopts'] = "export HSA_RUNTIME_PATH=%s && " % self.installdir
-        component['configopts'] = " ".join(self.llvm_compiler_flags)
-        component['configopts'] += " -DLIBOMPTARGET_AMDGCN_GFXLIST='%s'" % ';'.join(self.amd_gfx_archs)
-        component['configopts'] += " -DLIBOMPTARGET_ENABLE_DEBUG=ON"
-        component['configopts'] += " -DLIBOMPTARGET_LLVM_INCLUDE_DIRS=%s" % llvm_include_dir
-        component['configopts'] += " -DLIBOMP_COPY_EXPORTS=OFF"
-        component['configopts'] += " -DLLVM_MAIN_INCLUDE_DIR=%s" % llvm_include_dir
-        component['configopts'] += " -DOPENMP_ENABLE_LIBOMPTARGET=ON"
-        component['configopts'] += " -DOPENMP_ENABLE_LIBOMPTARGET_HSA=ON"
-        component['configopts'] += " -DROCDL=%s" % self.device_lib_path
-        component['configopts'] += " -DROCM_DIR=%s" % self.installdir
-        component['configopts'] += " -DAOMP_STANDALONE_BUILD=1"
+
+        component['configopts'] = ' '.join(self.llvm_compiler_flags + [
+            "-DLIBOMPTARGET_AMDGCN_GFXLIST='%s'" % ';'.join(self.amd_gfx_archs),
+            "-DLIBOMPTARGET_ENABLE_DEBUG=ON",
+            "-DLIBOMPTARGET_LLVM_INCLUDE_DIRS=%s" % llvm_include_dir,
+            "-DLIBOMP_COPY_EXPORTS=OFF",
+            "-DLLVM_MAIN_INCLUDE_DIR=%s" % llvm_include_dir,
+            "-DOPENMP_ENABLE_LIBOMPTARGET=ON",
+            "-DOPENMP_ENABLE_LIBOMPTARGET_HSA=ON",
+            "-DROCDL=%s" % self.device_lib_path,
+            "-DROCM_DIR=%s" % self.installdir,
+            "-DAOMP_STANDALONE_BUILD=1",
+            '',
+        ])
+
         if get_software_root('CUDA'):
             llvm_link = os.path.join(self.installdir, 'bin', 'llvm-link')
             cuda_path = os.path.join(self.installdir, 'bin', 'clang++')
-            component['configopts'] += " -DLIBOMPTARGET_NVPTX_BC_LINKER=%s" % llvm_link
-            component['configopts'] += " -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES='%s'" % ','.join(self.cuda_archs)
-            component['configopts'] += " -DLIBOMPTARGET_NVPTX_CUDA_COMPILER=%s" % cuda_path
-            component['configopts'] += " -DLIBOMPTARGET_NVPTX_ENABLE_BCLIB=ON"
+            component['configopts'] += ' '.join([
+                "-DLIBOMPTARGET_NVPTX_BC_LINKER=%s" % llvm_link,
+                "-DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES='%s'" % ','.join(self.cuda_archs),
+                "-DLIBOMPTARGET_NVPTX_CUDA_COMPILER=%s" % cuda_path,
+                "-DLIBOMPTARGET_NVPTX_ENABLE_BCLIB=ON",
+            ])
 
     def _configure_aomp_extras(self, component):
         """
@@ -238,7 +268,9 @@ class EB_Clang_AOMP(Bundle):
         """
         component['preconfigopts'] = "export AOMP=%s && " % self.installdir
         component['preconfigopts'] += "export GFXLIST='%s' && " % ';'.join(self.amd_gfx_archs)
-        component['configopts'] = " ".join(self.llvm_compiler_flags)
-        component['configopts'] += " -DAOMP_STANDALONE_BUILD=1"
-        component['configopts'] += " -DROCDL=%s" % self.device_lib_path
-        component['configopts'] += " -DROCM_DIR=%s" % self.installdir
+
+        component['configopts'] = ' '.join(self.llvm_compiler_flags + [
+            "-DAOMP_STANDALONE_BUILD=1",
+            "-DROCDL=%s" % self.device_lib_path,
+            "-DROCM_DIR=%s" % self.installdir,
+        ])


### PR DESCRIPTION
@nordmoen for https://github.com/easybuilders/easybuild-easyblocks/pull/2617

Most important changes:

* use `EB_Clang_minus_AOMP` as class name, so `easyblock` line in easyconfig is not needed
* move defining of `self.amd_gfx_archs` to easyblock constructor, so it's always defined (important when using `--module-only`)
* use `get_cuda_cc_template_value` provided by EasyBuild framework (see https://github.com/easybuilders/easybuild-framework/pull/3807)
* don't check for `libm-amdgcn-*.bc` in sanity check, because it is not there for all target `gfx*` (for example, there's only `libm-amdgcn-gfx900.bc`, no `libm-amdgcn-gfx908.bc`)
* bypass `sanity_check_step` of `Bundle`, so custom paths/commands defined in `Clang-AOMP` are actually used

(in addition, several code style changes that help with readability)